### PR TITLE
提交编译并发布release的action

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -40,6 +40,17 @@ jobs:
     needs: [build-windows, build-macos]
     runs-on: ubuntu-latest
     steps:
+    - name: Set up current date and time
+      uses: Kaven-Universe/github-action-current-date-time@v1
+      id: date
+      with:
+        format: 'YYYYMMDD'
+    - name: short time
+      id: short_time
+      run: |
+        $val = "${{ steps.date.outputs.time }}"
+        $last6 = $val.Substring($val.Length - 6)
+        echo "time=$last6" >> $env:GITHUB_OUTPUT
     - name: Download All Artifacts
       uses: actions/download-artifact@v5
       with: 
@@ -49,8 +60,8 @@ jobs:
     - name: Create Github Release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ inputs.version }}+build${{ needs.build-windows.outputs.build_time }}
-        name: BuckyOSApp Release ${{ inputs.version }}+build${{ needs.build-windows.outputs.build_time }}
+        tag_name: ${{ inputs.version }}+build${{ steps.short_time.outputs.time }}
+        name: BuckyOSApp Release ${{ inputs.version }}+build${{ steps.short_time.outputs.time }}
         generate_release_notes: true
         fail_on_unmatched_files: true
         files: "*.tar.gz"

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -45,9 +45,8 @@ jobs:
     - name: short time
       id: short_time
       run: |
-        $val="${{ steps.date.outputs.time }}"
-        $last6=$val.Substring($val.Length - 6)
-        echo "time=$last6" >> $env:GITHUB_OUTPUT
+        val="${{ steps.date.outputs.time }}"
+        echo "time=${val: -6}" >> $GITHUB_OUTPUT
     - name: Download All Artifacts
       uses: actions/download-artifact@v5
       with: 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -13,9 +13,6 @@ on:
         description: 'Version number'
         required: true
         type: string
-    outputs:
-      build_time:
-        value: ${{jobs.build-windows.outputs.build_time}}
 
 jobs:
   build-windows:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -1,0 +1,58 @@
+name: Build All
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version number'
+        required: true
+        type: string
+    outputs:
+      build_time:
+        value: ${{jobs.build-windows.outputs.build_time}}
+
+jobs:
+  build-windows:
+    strategy:
+      matrix:
+        arch: ["x86_64", "aarch64"]
+    uses: ./.github/workflows/build-windows.yml
+    with:
+      version: ${{ inputs.version }}
+      arch: ${{ matrix.arch }}
+    secrets: inherit
+  build-macos:
+    strategy:
+      matrix:
+        arch: ["x86_64", "aarch64"]
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      version: ${{ inputs.version }}
+      arch: ${{ matrix.arch }}
+    secrets: inherit
+  publish-release:
+    needs: [build-windows, build-macos]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download All Artifacts
+      uses: actions/download-artifact@v5
+      with: 
+        merge-multiple: true
+    - name: List Files
+      run: ls -alh .
+    - name: Create Github Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ inputs.version }}+build${{ needs.build-windows.outputs.build_time }}
+        name: BuckyOSApp Release ${{ inputs.version }}+build${{ needs.build-windows.outputs.build_time }}
+        generate_release_notes: true
+        fail_on_unmatched_files: true
+        files: "*.tar.gz"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -45,8 +45,8 @@ jobs:
     - name: short time
       id: short_time
       run: |
-        $val = "${{ steps.date.outputs.time }}"
-        $last6 = $val.Substring($val.Length - 6)
+        $val="${{ steps.date.outputs.time }}"
+        $last6=$val.Substring($val.Length - 6)
         echo "time=$last6" >> $env:GITHUB_OUTPUT
     - name: Download All Artifacts
       uses: actions/download-artifact@v5

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,32 +1,18 @@
 name: Build Buckyos Desktop MacOS Version
 on:
     workflow_call:
-            inputs:
-                version:
-                    required: true
-                    type: string
-                arch:
-                    required: true
-                    type: string
-            outputs:
-                build_time:
-                    value: ${{jobs.build.outputs.build_time}}
+        inputs:
+            version:
+                required: true
+                type: string
+            arch:
+                required: true
+                type: string
 
 jobs:
     build:
         runs-on: ${{ inputs.arch == 'aarch64' && 'macos-15' || 'macos-15-intel' }}
         steps:
-            - name: Set up current date and time
-              uses: Kaven-Universe/github-action-current-date-time@v1
-              id: date
-              with:
-                format: 'YYYYMMDD'
-            - name: short time
-              id: short_time
-              run: |
-                $val = "${{ steps.date.outputs.time }}"
-                $last6 = $val.Substring($val.Length - 6)
-                echo "last6=$last6" >> $env:GITHUB_OUTPUT
             - name: Checkout
               uses: actions/checkout@v4
             - name: Setup pnpm
@@ -61,5 +47,3 @@ jobs:
                 name: BuckyOSApp-apple-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
                 path: BuckyOSApp-apple-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}.tar.gz
                 if-no-files-found: error
-        outputs:
-          build_time: ${{ steps.date.outputs.time }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -38,7 +38,7 @@ jobs:
             - name: Perpare artifact
               run: |
                 mkdir -p release/BuckyOSApp/${{inputs.version}}/BuckyOSApp-apple-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
-                copy src-tauri/target/release/buckyosapp release/BuckyOSApp/${{inputs.version}}/BuckyOSApp-apple-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
+                cp src-tauri/target/release/buckyosapp release/BuckyOSApp/${{inputs.version}}/BuckyOSApp-apple-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
                 tar -czvf BuckyOSApp-apple-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}.tar.gz -C release .
             - name: Upload Artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,65 @@
+name: Build Buckyos Desktop MacOS Version
+on:
+    workflow_call:
+            inputs:
+                version:
+                    required: true
+                    type: string
+                arch:
+                    required: true
+                    type: string
+            outputs:
+                build_time:
+                    value: ${{jobs.build.outputs.build_time}}
+
+jobs:
+    build:
+        runs-on: ${{ inputs.arch == 'aarch64' && 'macos-15' || 'macos-15-intel' }}
+        steps:
+            - name: Set up current date and time
+              uses: Kaven-Universe/github-action-current-date-time@v1
+              id: date
+              with:
+                format: 'YYYYMMDD'
+            - name: short time
+              id: short_time
+              run: |
+                $val = "${{ steps.date.outputs.time }}"
+                $last6 = $val.Substring($val.Length - 6)
+                echo "last6=$last6" >> $env:GITHUB_OUTPUT
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                version: "latest"
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                node-version: '22.x'
+            - name: Setup Rust
+              uses: dtolnay/rust-toolchain@stable
+              with:
+                toolchain: stable
+                targets: ${{inputs.arch}}-apple-darwin
+            - name: Install dependencies
+              run: pnpm install
+            - name: Update Cargo
+              run: cargo update
+              working-directory: ./src-tauri
+            - name: Build Buckyos Desktop
+              run: pnpm tauri build --no-bundle
+            - name: Perpare artifact
+              run: |
+                mkdir -p release/BuckyOSApp/${{inputs.version}}/BuckyOSApp-apple-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
+                copy src-tauri/target/release/buckyosapp release/BuckyOSApp/${{inputs.version}}/BuckyOSApp-apple-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
+                tar -czvf BuckyOSApp-apple-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}.tar.gz -C release .
+            - name: Upload Artifact
+              uses: actions/upload-artifact@v4
+              id: upload
+              with:
+                name: BuckyOSApp-apple-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
+                path: BuckyOSApp-apple-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}.tar.gz
+                if-no-files-found: error
+        outputs:
+          build_time: ${{ steps.date.outputs.time }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -30,8 +30,6 @@ jobs:
                 targets: ${{inputs.arch}}-pc-windows-msvc
             - name: Setup MSVC
               uses: ilammy/msvc-dev-cmd@v1
-              with:
-                arch: ${{ inputs.arch == 'aarch64' && 'amd64_arm64' || 'amd64' }}
             - name: Install dependencies
               run: pnpm install
             - name: Update Cargo

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -36,11 +36,11 @@ jobs:
               run: cargo update
               working-directory: ./src-tauri
             - name: Build Buckyos Desktop
-              run: pnpm tauri build --no-bundle
+              run: pnpm tauri build --no-bundle -- --target ${{inputs.arch}}-pc-windows-msvc
             - name: Perpare artifact
               run: |
                 mkdir -p release\BuckyOSApp\${{inputs.version}}\BuckyOSApp-windows-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
-                copy src-tauri\target\release\buckyosapp.exe release\BuckyOSApp\${{inputs.version}}\BuckyOSApp-windows-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
+                copy src-tauri\target\${{inputs.arch}}-pc-windows-msvc\release\buckyosapp.exe release\BuckyOSApp\${{inputs.version}}\BuckyOSApp-windows-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
                 tar -czvf BuckyOSApp-windows-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}.tar.gz -C release .
             - name: Upload Artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,69 @@
+name: Build Buckyos Desktop Windows Version
+on:
+    workflow_call:
+            inputs:
+                version:
+                    required: true
+                    type: string
+                arch:
+                    required: true
+                    type: string
+            outputs:
+                build_time:
+                    value: ${{jobs.build.outputs.build_time}}
+
+jobs:
+    build:
+        runs-on: ${{ inputs.arch == 'aarch64' && 'windows-11-arm' || 'windows-2025' }}
+        steps:
+            - name: Set up current date and time
+              uses: Kaven-Universe/github-action-current-date-time@v1
+              id: date
+              with:
+                format: 'YYYYMMDD'
+            - name: short time
+              id: short_time
+              run: |
+                $val = "${{ steps.date.outputs.time }}"
+                $last6 = $val.Substring($val.Length - 6)
+                echo "last6=$last6" >> $env:GITHUB_OUTPUT
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                version: "latest"
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                node-version: '22.x'
+            - name: Setup Rust
+              uses: dtolnay/rust-toolchain@stable
+              with:
+                toolchain: stable
+                targets: ${{inputs.arch}}-pc-windows-msvc
+            - name: Setup MSVC
+              uses: ilammy/msvc-dev-cmd@v1
+              with:
+                arch: ${{ inputs.arch == 'aarch64' && 'amd64_arm64' || 'amd64' }}
+            - name: Install dependencies
+              run: pnpm install
+            - name: Update Cargo
+              run: cargo update
+              working-directory: ./src-tauri
+            - name: Build Buckyos Desktop
+              run: pnpm tauri build --no-bundle
+            - name: Perpare artifact
+              run: |
+                mkdir -p release\BuckyOSApp\${{inputs.version}}\BuckyOSApp-windows-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
+                copy src-tauri\target\release\buckyosapp.exe release\BuckyOSApp\${{inputs.version}}\BuckyOSApp-windows-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
+                tar -czvf BuckyOSApp-windows-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}.tar.gz -C release .
+            - name: Upload Artifact
+              uses: actions/upload-artifact@v4
+              id: upload
+              with:
+                name: BuckyOSApp-windows-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
+                path: BuckyOSApp-windows-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}.tar.gz
+                if-no-files-found: error
+        outputs:
+          build_time: ${{ steps.date.outputs.time }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,32 +1,18 @@
 name: Build Buckyos Desktop Windows Version
 on:
     workflow_call:
-            inputs:
-                version:
-                    required: true
-                    type: string
-                arch:
-                    required: true
-                    type: string
-            outputs:
-                build_time:
-                    value: ${{jobs.build.outputs.build_time}}
+        inputs:
+            version:
+                required: true
+                type: string
+            arch:
+                required: true
+                type: string
 
 jobs:
     build:
         runs-on: ${{ inputs.arch == 'aarch64' && 'windows-11-arm' || 'windows-2025' }}
         steps:
-            - name: Set up current date and time
-              uses: Kaven-Universe/github-action-current-date-time@v1
-              id: date
-              with:
-                format: 'YYYYMMDD'
-            - name: short time
-              id: short_time
-              run: |
-                $val = "${{ steps.date.outputs.time }}"
-                $last6 = $val.Substring($val.Length - 6)
-                echo "last6=$last6" >> $env:GITHUB_OUTPUT
             - name: Checkout
               uses: actions/checkout@v4
             - name: Setup pnpm
@@ -65,5 +51,3 @@ jobs:
                 name: BuckyOSApp-windows-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}
                 path: BuckyOSApp-windows-${{inputs.arch == 'x86_64' && 'amd64' || 'aarch64'}}.tar.gz
                 if-no-files-found: error
-        outputs:
-          build_time: ${{ steps.date.outputs.time }}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -571,8 +571,8 @@ dependencies = [
  "anyhow",
  "bip39",
  "bitcoin",
- "get_if_addrs",
  "hex",
+ "if-addrs",
  "jsonwebtoken",
  "log",
  "name-lib",
@@ -660,12 +660,6 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "c_linked_list"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cairo-rs"
@@ -1249,7 +1243,7 @@ dependencies = [
  "dlopen2_derive",
  "libc",
  "once_cell",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1696,12 +1690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
 name = "gdk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,28 +1799,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "get_if_addrs"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
-dependencies = [
- "c_linked_list",
- "get_if_addrs-sys",
- "libc",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "get_if_addrs-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
-dependencies = [
- "gcc",
- "libc",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,7 +1881,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2434,6 +2400,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,7 +2720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3033,7 +3009,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -5911,7 +5887,7 @@ checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
 dependencies = [
  "memoffset",
  "tempfile",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6360,12 +6336,6 @@ name = "widestring"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,7 +40,7 @@ name-lib = { git = "https://github.com/buckyos/buckyos-base.git", package = "nam
 secrecy = "0.8"
 zeroize = "1.7"
 jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
-get_if_addrs = "0.5"
+if-addrs = "*"
 tauri-plugin-http = "2"
 
 [features]

--- a/src-tauri/src/network/network.rs
+++ b/src-tauri/src/network/network.rs
@@ -1,4 +1,4 @@
-use get_if_addrs::get_if_addrs;
+use if_addrs::get_if_addrs;
 
 #[tauri::command]
 pub fn local_ipv4_list() -> Result<Vec<String>, String> {


### PR DESCRIPTION
可以手动触发Build All的Action，编译[windows, macos]x[amd64, aarch64]平台的可执行文件，并打包发布到release

将rust的get_if_addrs包替换成if_addrs包，解决windows aarch64编译失败的问题

当前项目中没有版本号的配置，当前触发action时手动填写。之后考虑增加类似buckyos_project的描述文件